### PR TITLE
Minor fixes of abstracts

### DIFF
--- a/_posts/2007-03-11-carreau07a.md
+++ b/_posts/2007-03-11-carreau07a.md
@@ -1,7 +1,7 @@
 ---
 title: A Hybrid Pareto Model for Conditional Density Estimation of Asymmetric Fat-Tail
   Data
-abstract: 'We propose an estimator for the conditional density p(Y |X) that can adapt
+abstract: 'We propose an estimator for the conditional density $p(Y \mid X)$ that can adapt
   for asymmetric heavy tails which might depend on X. Such estimators have important
   applications in nance and insurance. We draw from Extreme Value Theory the tools
   to build a hybrid unimodal density having a parameter controlling the heaviness
@@ -9,7 +9,7 @@ abstract: 'We propose an estimator for the conditional density p(Y |X) that can 
   by a generalized Pareto tail. We use this hybrid in a multi-modal mixture in order
   to obtain a nonparametric density estimator that can easily adapt for heavy tailed
   data. To obtain a conditional density estimator, the parameters of the mixture estimator
-  can be seen as functions of X and these functions learned. We show experimentally
+  can be seen as functions of $X$ and these functions learned. We show experimentally
   that this approach better models the conditional density in terms of likelihood
   than compared competing algorithms : conditional mixture models with other types
   of components and multivariate nonparametric models.'

--- a/_posts/2007-03-11-cook07a.md
+++ b/_posts/2007-03-11-cook07a.md
@@ -7,8 +7,8 @@ abstract: We show how to visualize a set of pairwise similarities between object
   be close to “bank” without being at all close to each other. Aspect maps resemble
   clustering because they model pair-wise similarities as a mixture of different types
   of similarity, but they also resemble local multi-dimensional scaling because they
-  model each type of similarity by a twodimensional map. We demonstrate our method
-  on a toy example, a database of human wordassociation data, a large set of images
+  model each type of similarity by a two-dimensional map. We demonstrate our method
+  on a toy example, a database of human word association data, a large set of images
   of handwritten digits, and a set of feature vectors that represent words.
 pdf: http://proceedings.mlr.press/v2/cook07a/cook07a.pdf
 layout: inproceedings

--- a/_posts/2007-03-11-eaton07a.md
+++ b/_posts/2007-03-11-eaton07a.md
@@ -1,8 +1,8 @@
 ---
 title: Exact Bayesian structure learning from uncertain interventions
 abstract: We show how to apply the dynamic programming algorithm of Koivisto and Sood
-  [KS04, Koi06], which computes the exact posterior marginal edge probabilities p(G_ij
-  = 1|D) of a DAG G given data D, to the case where the data is obtained by interventions
+  [KS04, Koi06], which computes the exact posterior marginal edge probabilities $p(G_{ij}
+  = 1 \mid D)$ of a DAG $G$ given data $D$, to the case where the data is obtained by interventions
   (experiments). In particular, we consider the case where the targets of the interventions
   are a priori unknown. We show that it is possible to learn the targets of intervention
   at the same time as learning the causal structure. We apply our exact technique

--- a/_posts/2007-03-11-huang07a.md
+++ b/_posts/2007-03-11-huang07a.md
@@ -6,7 +6,7 @@ abstract: We formulate the weighted b-matching objective function as a probabili
   in polynomial time, but we introduce an algebraic method to circumvent the combinatorial
   message updates. Empirically, the resulting algorithm is on average faster than
   popular combinatorial implementations, while still scaling at the same asymptotic
-  rate of O(bn^3). Furthermore, the algorithm shows promising performance in machine
+  rate of $O(bn^3)$. Furthermore, the algorithm shows promising performance in machine
   learning applications.
 pdf: http://proceedings.mlr.press/v2/huang07a/huang07a.pdf
 layout: inproceedings

--- a/_posts/2007-03-11-krupka07a.md
+++ b/_posts/2007-03-11-krupka07a.md
@@ -4,13 +4,13 @@ abstract: In the standard formulation of supervised learning the input is repres
   as a vector of features.  However, in most real-life problems, we also have additional
   information about each of the features.  This information can be represented as
   a set of properties, referred to as meta-features. For instance, in an image recognition
-  task, where the features are pixels, the meta-features can be the (x, y) position
-  of each pixel. We propose a new learning framework that incorporates meta- features.  In
+  task, where the features are pixels, the meta-features can be the $(x, y)$ position
+  of each pixel. We propose a new learning framework that incorporates meta-features.  In
   this framework we assume that a weight is assigned to each feature, as in linear
   discrimination, and we use the meta-features to define a prior on the weights. This
   prior is based on a Gaussian process and the weights are assumed to be a smooth
   function of the meta-features. Using this framework we derive a practical algorithm
-  that improves gen- eralization by using meta-features and discuss the theoretical
+  that improves generalization by using meta-features and discuss the theoretical
   advantages of incorporating them into the learning. We apply our framework to design
   a new kernel for hand-written digit recognition. We obtain higher accuracy with
   lower computational complexity in the primal representation. Finally, we discuss

--- a/_posts/2007-03-11-lee07a.md
+++ b/_posts/2007-03-11-lee07a.md
@@ -2,7 +2,7 @@
 title: Treelets | A Tool for Dimensionality Reduction and Multi-Scale Analysis of
   Unstructured Data
 abstract: In many modern data mining applications, such as analysis of gene expression
-  or worddocument data sets, the data is highdimensional with hundreds or even thousands
+  or word-document data sets, the data is high-dimensional with hundreds or even thousands
   of variables, unstructured with no specific order of the original variables, and
   noisy. Despite the high dimensionality, the data is typically redundant with underlying
   structures that can be represented by only a few features. In such settings and

--- a/_posts/2007-03-11-liu07a.md
+++ b/_posts/2007-03-11-liu07a.md
@@ -1,7 +1,7 @@
 ---
 title: Sparse Nonparametric Density Estimation in High Dimensions Using the Rodeo
-abstract: We consider the problem of estimating the joint density of a d-dimensional
-  random vector X = (X_1 , X_2, ..., X_d ) when d is large. We assume that the density
+abstract: We consider the problem of estimating the joint density of a $d$-dimensional
+  random vector $X = (X_1 , X_2, ..., X_d )$ when d is large. We assume that the density
   is a product of a parametric component and a nonparametric component which depends
   on an unknown subset of the variables. Using a modification of a recently developed
   nonparametric regression framework called rodeo (regularization of derivative expectation

--- a/_posts/2007-03-11-madani07a.md
+++ b/_posts/2007-03-11-madani07a.md
@@ -1,7 +1,7 @@
 ---
 title: 'Recall Systems: Effcient Learning and Use of Category Indices'
 abstract: We introduce the framework of recall systems for efficient learning and
-  retrieval of categories when the number of categories is large. A recallsystem here
+  retrieval of categories when the number of categories is large. A recall system here
   is a simple feature-based intermediate filtering step which reduces the potential
   categories for an instance to a small manageable set. The correct categories from
   this set can then be determined using traditional classifiers. We present a formalization

--- a/_posts/2007-03-11-mansinghka07a.md
+++ b/_posts/2007-03-11-mansinghka07a.md
@@ -1,7 +1,7 @@
 ---
 title: 'AClass: A simple, online, parallelizable algorithm for probabilistic classification'
 abstract: We present AClass, a simple, online, parallelizable algorithm for supervised
-  multiclass classification. AClass models each classconditional density as a Chinese
+  multiclass classification. AClass models each class-conditional density as a Chinese
   restaurant process mixture, and performs approximate inference in this model using
   a sequential Monte Carlo scheme. AClass combines several strengths of previous approaches
   to classification that are not typically found in a single algorithm; it supports

--- a/_posts/2007-03-11-mcmahan07a.md
+++ b/_posts/2007-03-11-mcmahan07a.md
@@ -7,9 +7,9 @@ abstract: Convex games are a natural generalization of matrix (normal-form) game
   to identify search directions; the algorithm then does an exact minimization in
   this direction via a specialized line search. We test the algorithm on a simplified
   version of Texas Hold’em poker represented as an extensive-form game. Our algorithm
-  approximated the exact value of this game within 0.20 (the maximum pot size is 310.00)
+  approximated the exact value of this game within \$0.20 (the maximum pot size is \$310.00)
   in a little over 2 hours, using less than 1.5GB of memory; finding a solution with
-  comparable bounds using a state-of-theart interior-point linear programming algorithm
+  comparable bounds using a state-of-the-art interior-point linear programming algorithm
   took over 4 days and 25GB of memory.
 pdf: http://proceedings.mlr.press/v2/mcmahan07a/mcmahan07a.pdf
 layout: inproceedings

--- a/_posts/2007-03-11-mooij07a.md
+++ b/_posts/2007-03-11-mooij07a.md
@@ -6,7 +6,7 @@ abstract: 'We propose a method for improving Belief Propagation (BP) that takes 
   It consists of two steps: (i) standard BP is used to calculate cavity distributions
   for each variable (i.e. probability distributions on the Markov blanket of a variable
   for a modified graphical model, in which the factors involving that variable have
-  been removed); (ii) all cavity distributions are combined by a messagepassing algorithm
+  been removed); (ii) all cavity distributions are combined by a message-passing algorithm
   to obtain consistent single node marginals. The method is exact if the graphical
   model contains a single loop. The complexity of the method is exponential in the
   size of the Markov blankets. The results are very accurate in general: the error

--- a/_posts/2007-03-11-raykar07a.md
+++ b/_posts/2007-03-11-raykar07a.md
@@ -4,7 +4,7 @@ abstract: We consider the problem of learning the ranking function that maximize
   a generalization of the Wilcoxon-Mann-Whitney statistic on training data. Relying
   on an -exact approximation for the error-function, we reduce the computational complexity
   of each iteration of a conjugate gradient algorithm for learning ranking functions
-  from O(m^2), to O(m), where m is the size of the training data. Experiments on public
+  from $O(m^2)$, to $O(m)$, where $m$ is the size of the training data. Experiments on public
   benchmarks for ordinal regression and collaborative filtering show that the proposed
   algorithm is as accurate as the best available methods in terms of ranking accuracy,
   when trained on the same data, and is several orders of magnitude faster.

--- a/_posts/2007-03-11-salakhutdinov07a.md
+++ b/_posts/2007-03-11-salakhutdinov07a.md
@@ -1,7 +1,7 @@
 ---
 title: Learning a Nonlinear Embedding by Preserving Class Neighbourhood Structure
 abstract: We show how to pretrain and fine-tune a multilayer neural network to learn
-  a nonlinear transformation from the input space to a lowdimensional feature space
+  a nonlinear transformation from the input space to a low-dimensional feature space
   in which K-nearest neighbour classification performs well. We also show how the
   non-linear transformation can be improved using unlabeled data. Our method achieves
   a much lower error rate than Support Vector Machines or standard backpropagation

--- a/_posts/2007-03-11-sarkar07a.md
+++ b/_posts/2007-03-11-sarkar07a.md
@@ -2,7 +2,7 @@
 title: A Latent Space Approach to Dynamic Embedding of Co-occurrence Data
 abstract: 'We consider dynamic co-occurrence data, such as author-word links in papers
   published in successive years of the same conference. For static co-occurrence data,
-  researchers often seek an embedding of the entities (authors and words) into a lowdimensional
+  researchers often seek an embedding of the entities (authors and words) into a low-dimensional
   Euclidean space. We generalize a recent static co-occurrence model, the CODE model
   of Globerson et al. (2004), to the dynamic setting: we seek coordinates for each
   entity at each time step. The coordinates can change with time to explain new observations,

--- a/_posts/2007-03-11-schaffoner07a.md
+++ b/_posts/2007-03-11-schaffoner07a.md
@@ -7,7 +7,7 @@ abstract: A novel training algorithm for sparse kernel density estimates by regr
   selection procedure using updates of the orthogonal decomposition in an order-recursive
   manner. We also present a method for improving the accuracy of the estimated models
   which uses output-sensitive computation of the ECDF. Experiments show the superior
-  performance of our proposed method compared to stateof-the-art density estimation
+  performance of our proposed method compared to state-of-the-art density estimation
   methods such as Parzen windows, Gaussian Mixture Models, and ε-Support Vector Density
   models [1].
 pdf: http://proceedings.mlr.press/v2/schaffoner07a/schaffoner07a.pdf

--- a/_posts/2007-03-11-silva07a.md
+++ b/_posts/2007-03-11-silva07a.md
@@ -3,10 +3,10 @@ title: Analogical Reasoning with Relational Bayesian Sets
 abstract: 'Analogical reasoning depends fundamentally on the ability to learn and
   generalize about relations between objects. There are many ways in which objects
   can be related, making automated analogical reasoning very challenging. Here we
-  develop an approach which, given a set of pairs of related objects S = {A^1:B^1,
-  A^2:B^2, ..., A^N:B^N }, measures how well other pairs A:B fit in with the set S.
-  This addresses the question: is the relation between objects A and B analogous to
-  those relations found in S? We recast this classical problem as a problem of Bayesian
+  develop an approach which, given a set of pairs of related objects $\mathbf{S} = \{A^1:B^1,
+  A^2:B^2, \ldots, A^N:B^N \}$, measures how well other pairs $A:B$ fit in with the set $\mathbf{S}$.
+  This addresses the question: is the relation between objects $A$ and $B$ analogous to
+  those relations found in $\mathbf{S}$? We recast this classical problem as a problem of Bayesian
   analysis of relational data. This problem is nontrivial because direct similarity
   between objects is not a good way of measuring analogies. For instance, the analogy
   between an electron around the nucleus of an atom and a planet around the Sun is

--- a/_posts/2007-03-11-siracusa07a.md
+++ b/_posts/2007-03-11-siracusa07a.md
@@ -7,7 +7,7 @@ abstract: The goal of a dynamic dependency test is to correctly label the intera
   on observations. We show that a dynamic dependency test using an HFactMM takes advantage
   of both structural and parametric changes associated with changes in interaction.
   This is contrasted both theoretically and empirically with standard sliding window
-  based dependence analysis. Using this model we obtain state-ofthe-art performance
+  based dependence analysis. Using this model we obtain state-of-the-art performance
   on an audio-visual association task without the benefit of labeled training data.
 pdf: http://proceedings.mlr.press/v2/siracusa07a/siracusa07a.pdf
 layout: inproceedings

--- a/_posts/2007-03-11-snelson07a.md
+++ b/_posts/2007-03-11-snelson07a.md
@@ -10,7 +10,7 @@ abstract: Gaussian process (GP) models are flexible probabilistic nonparametric 
   the regimes in which these different approaches work well or fail. We then proceed
   to develop a new sparse GP approximation which is a combination of both the global
   and local approaches. Theoretically we show that it is derived as a natural extension
-  of the framework developed by Qui onero Candela and Rasmussen [2005] for n sparse
+  of the framework developed by Quiñonero Candela and Rasmussen [2005] for n sparse
   GP approximations. We demonstrate the benefits of the combined approximation on
   some 1D examples for illustration, and on some large real-world data sets.
 pdf: http://proceedings.mlr.press/v2/snelson07a/snelson07a.pdf

--- a/_posts/2007-03-11-sunehag07a.md
+++ b/_posts/2007-03-11-sunehag07a.md
@@ -11,7 +11,7 @@ abstract: Several authors have recently studied the problem of creating exchange
   models since they, just like some recently introduced models for the abundance of
   rare species in ecology, seperate the issue of presence from the issue of abundance
   when present. We will see that the widely used TF-IDF heuristic for information
-  retrieval follows naturally from these models by calculating a crossentropy. We
+  retrieval follows naturally from these models by calculating a cross-entropy. We
   will also discuss a connection between TF-IDF and file formats that seperate presence
   from abundance given presence.
 pdf: http://proceedings.mlr.press/v2/sunehag07a/sunehag07a.pdf

--- a/_posts/2007-03-11-venna07a.md
+++ b/_posts/2007-03-11-venna07a.md
@@ -1,7 +1,7 @@
 ---
 title: Nonlinear Dimensionality Reduction as Information Retrieval
 abstract: 'Nonlinear dimensionality reduction has so far been treated either as a
-  data representation problem or as a search for a lowerdimensional manifold embedded
+  data representation problem or as a search for a lower-dimensional manifold embedded
   in the data space. A main application for both is in information visualization,
   to make visible the neighborhood or proximity relationships in the data, but neither
   approach has been designed to optimize this task. We give such visualization a new

--- a/_posts/2007-03-11-weinberger07a.md
+++ b/_posts/2007-03-11-weinberger07a.md
@@ -8,7 +8,7 @@ abstract: Kernel regression is a well-established method for nonlinear regressio
   for supervised metric learning, which learns a distance function by directly minimizing
   the leave-one-out regression error. We show that our algorithm makes kernel regression
   comparable with the state of the art on several benchmark datasets, and we provide
-  efficient implementation details enabling application to datasets with  O(10k) instances.
+  efficient implementation details enabling application to datasets with $\sim O$(10k) instances.
   Further, we show that our algorithm can be viewed as a supervised variation of PCA
   and can be used for dimensionality reduction and high dimensional data visualization.
 pdf: http://proceedings.mlr.press/v2/weinberger07a/weinberger07a.pdf


### PR DESCRIPTION
This PR includes mainly the following minor fixes for the abstracts: 

- Fix typos of words using a hyphen
    - If such a word appears at the end of a line in an abstract, this typo happens
- Use math format